### PR TITLE
Fix byte-compile warnings

### DIFF
--- a/jma-forecast.el
+++ b/jma-forecast.el
@@ -129,6 +129,7 @@
 
 (require 'jma-utils)
 (require 'jma-weather-code)
+(require 'parse-time)
 
 ;;;; 天気予報
 
@@ -472,7 +473,7 @@ WEEK-AMEDAS-CODE 週間予報における気温を取得するためのAMEDAS観
                        amedas-code
                        week-area-code
                        week-amedas-code)))
-    (when (interactive-p)
+    (when (called-interactively-p 'interactive)
       (message "%s" (prin1-to-string result)))
     result))
 


### PR DESCRIPTION
```
In jma-forecast-area-read:
jma-forecast.el:476:12: Warning: ‘interactive-p’ is an obsolete function (as
    of 23.2); use ‘called-interactively-p’ instead.

In end of data:
jma-forecast.el:226:4: Warning: the function ‘parse-iso8601-time-string’ is
    not known to be defined.
```